### PR TITLE
Build the Keyboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-  "name": "client",
-  "version": "0.1.0",
+  "name": "sec-directory-client",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "name": "sec-directory-client",
+      "version": "0.0.1",
       "dependencies": {
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^11.2.7",
@@ -17,8 +18,8 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "4.0.3",
-        "typescript": "^4.3.5",
-        "web-vitals": "^1.1.2"
+        "react-simple-keyboard": "^3.2.50",
+        "typescript": "^4.3.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -16528,6 +16529,15 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/react-simple-keyboard": {
+      "version": "3.2.50",
+      "resolved": "https://registry.npmjs.org/react-simple-keyboard/-/react-simple-keyboard-3.2.50.tgz",
+      "integrity": "sha512-Pbdxg6yizeFHvplCM2fhuGFmafDc6ZqCbhwnqOFMhB3yAw+4KW4o5E/ebvkq/5nIpBagmFJcRL4iV6rF50B5bQ==",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0",
+        "react-dom": "^16.14.0 || ^17.0.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -20096,11 +20106,6 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "node_modules/web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -34158,6 +34163,12 @@
         }
       }
     },
+    "react-simple-keyboard": {
+      "version": "3.2.50",
+      "resolved": "https://registry.npmjs.org/react-simple-keyboard/-/react-simple-keyboard-3.2.50.tgz",
+      "integrity": "sha512-Pbdxg6yizeFHvplCM2fhuGFmafDc6ZqCbhwnqOFMhB3yAw+4KW4o5E/ebvkq/5nIpBagmFJcRL4iV6rF50B5bQ==",
+      "requires": {}
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -36996,11 +37007,6 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
+    "react-simple-keyboard": "^3.2.50",
     "typescript": "^4.3.5"
   },
   "scripts": {

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -5,6 +5,7 @@ import Main from '../Main';
 import { useState } from 'react';
 import { VIEW } from './views';
 import Welcome from '../Welcome';
+import OnScreenKeyboard from '../Keyboard';
 import {
   appName,
   welcomeBannerText,
@@ -12,6 +13,8 @@ import {
 } from './text';
 
 const App = () => {
+  const [searchInput, setSearchInput] = useState('');
+
   const [currentView] = useState<VIEW>(VIEW.WELCOME);
   return (
     <div className="app">
@@ -22,6 +25,11 @@ const App = () => {
             {welcomeInstructions}
           </Welcome>
         )}
+        <OnScreenKeyboard
+          searchQuery={searchInput}
+          searchUpdateHandler={setSearchInput}
+          triggerSearchHandler={() => {console.log(`SEARCH: ${searchInput}`)}}
+        /> 
       </Main>
       <Footer />
     </div>

--- a/src/Keyboard/Keyboard.css
+++ b/src/Keyboard/Keyboard.css
@@ -1,0 +1,55 @@
+.keyboard--backdrop {
+  background: #00000080;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+}
+
+.keyboard--modal {
+  background: #89272e;
+  position: absolute;
+  width: 720px;
+  display: flex;
+  flex-direction: column;
+}
+
+.keyboard--search-container {
+  background: #89272e;
+  width: 100;
+  display: flex;
+  justify-content: center;
+  padding: 1em;
+}
+
+.keyboard--search-input-label {
+  display: none;
+  visibility: hidden;
+}
+
+.keyboard--search-input {
+  background: #982b34;
+  color: #fff;
+  border: none; 
+  padding: 1em;
+  width: 100%;
+  font-size: 2em;
+  text-align: left;
+} 
+
+.keyboard--buttons {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1em;
+}
+
+.keyboard--cancel-button,
+.keyboard--search-button {
+  background: #fff;
+  color: #000;
+  font-size: 1.5em;
+  padding: 0.5em 1em;
+}

--- a/src/Keyboard/Keyboard.css
+++ b/src/Keyboard/Keyboard.css
@@ -39,6 +39,18 @@
   text-align: left;
 } 
 
+.hg-theme-default.keyboard--component {
+  background: #89272e;
+}
+
+.hg-theme-default.keyboard--component button {
+  border-radius: 0;
+  border: none;
+  font-size: 1.5em;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+}
+
 .keyboard--buttons {
   display: flex;
   justify-content: space-between;
@@ -52,4 +64,5 @@
   color: #000;
   font-size: 1.5em;
   padding: 0.5em 1em;
+  border: 0;
 }

--- a/src/Keyboard/__tests__/Keyboard.test.tsx
+++ b/src/Keyboard/__tests__/Keyboard.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, fireEvent} from '@testing-library/react';
+import { useState } from 'react';
+import Keyboard from '..';
+
+
+const KeyboardTester = (
+  { searchHandler }: { searchHandler: () => void }
+) => {
+  const [searchQuery, setSearchQuery] = useState('');
+  return (
+    <div>
+      <Keyboard 
+        searchQuery={searchQuery}
+        searchUpdateHandler={setSearchQuery}
+        triggerSearchHandler={searchHandler}
+      />
+      <p>Click outside</p>
+    </div>);
+}
+
+describe('Keyboard', function () {
+  let searchHandler: () => void;
+  beforeEach(function () {
+    searchHandler = jest.fn();
+ });
+  describe('Opening/Closing the keyboard', function () {
+    beforeEach(function () {
+      render(<KeyboardTester searchHandler={searchHandler} />);
+    });
+    describe('On initial render', function () {
+      it('Should not initially appear', function () {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+    });
+    describe('After clicking on document.body', function () {
+      beforeEach(function() {
+        fireEvent.click(document.body);
+      });
+      it('Should appear after clicking on the body', async function () {
+        expect(screen.queryByRole('dialog')).toBeInTheDocument();
+      });
+      describe('After clicking outside the modal', function () {
+        beforeEach(function() {
+          fireEvent.click(document.querySelector('.keyboard--backdrop')!);
+        });
+        it('Should disappear', function () {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+      });
+      describe('After clicking cancel', function () {
+        beforeEach(function() {
+          fireEvent.click(screen.getByText('cancel'));
+        });
+        it('Should disappear', function () {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+      });
+      describe('After clicking enter', function () {
+        beforeEach(function() {
+          fireEvent.click(screen.getByText('< enter'));
+        });
+        it('Should disappear', function () {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+      });
+      describe('After clicking Search', function() {
+        beforeEach(function() {
+          fireEvent.click(screen.getByText('search'));
+        });
+        it('Should disappear', function () {
+          expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+      });
+    });
+  });
+  describe('Input display', function () {
+    beforeEach(function () {
+      render(<KeyboardTester searchHandler={searchHandler} />);
+      fireEvent.click(document.body);
+    });
+    it('Should display the text entered in the keys', function () {
+      fireEvent.click(screen.getByText('s')) 
+      fireEvent.click(screen.getByText('e')) 
+      fireEvent.click(screen.getByText('a')) 
+      fireEvent.click(screen.getByText('s')) 
+      expect(screen.getByRole('textbox')).toHaveValue('seas');
+    });
+  });
+  describe('Upper- and lower-case handling', function () {
+    beforeEach(function () {
+      render(<KeyboardTester searchHandler={searchHandler} />)
+      fireEvent.click(document.body);
+    });
+    it('Should initially be lowercase', async function () {
+      const lowercase = await screen.findByText('a');
+      expect(lowercase).toBeInTheDocument();
+      const capital = screen.queryByText('Z');
+      expect(capital).not.toBeInTheDocument();
+    });
+    it('should display nothing in the input', function () {
+      expect(screen.getByRole('textbox')).toHaveValue('');
+    });
+    describe('Pressing Shift', function () {
+      beforeEach(function() {
+        fireEvent.click(screen.getAllByText('shift')[0]);
+      });
+      it('Should not change the input value', function () {
+        expect(screen.getByRole('textbox')).toHaveValue('');
+      });
+      it('Should make the characters in the keyboard uppercase', async function () {
+        const capital = await screen.findByText('A');
+        expect(capital).toBeInTheDocument();
+        const lowercase = screen.queryByText('z');
+        expect(lowercase).not.toBeInTheDocument();
+      });
+      it('Should revert to lowercase after the next character is pressed', async function () {
+        const capital = await screen.findByText('A');
+        fireEvent.click(capital);
+        const lowercase = await screen.findByText('z');
+        expect(screen.getByRole('textbox')).toHaveValue('A')
+        expect(capital).not.toBeInTheDocument();
+        expect(lowercase).toBeInTheDocument();
+        fireEvent.click(lowercase);
+        expect(screen.getByRole('textbox')).toHaveValue('Az');
+        expect(lowercase).toBeInTheDocument();
+      });
+      describe('Pressing Shift again', function () {
+        it('Should revert to lowercase', async function () {
+          fireEvent.click(screen.getAllByText('shift')[0]);
+          const lowercase = await screen.findByText('z')
+          expect(lowercase).toBeInTheDocument(); 
+          const capital = screen.queryByText('A');
+          expect(capital).not.toBeInTheDocument(); 
+        });
+      });
+    });
+    describe('Pressing Caps Lock', function () {
+      beforeEach(function() {
+        fireEvent.click(screen.getAllByText('caps')[0]);
+      });
+      it('Should not change the input value', function () {
+        expect(screen.getByRole('textbox').textContent).toStrictEqual('');
+      });
+      it('Should make the characters in the keyboard uppercase', async function () {
+        const capital = await screen.findByText('A');
+        expect(capital).toBeInTheDocument();
+        const lowercase = screen.queryByText('z');
+        expect(lowercase).not.toBeInTheDocument();
+      });
+      it('Should stay uppercase after the next character is pressed', async function () {
+        const capital = await screen.findByText('A');
+        fireEvent.click(capital);
+        expect(capital).toBeInTheDocument();
+        expect(await screen.findByRole('textbox')).toHaveValue('A')
+        const lowercase = screen.queryByText('z');
+        expect(lowercase).not.toBeInTheDocument();
+        const capitalTwo = await screen.findByText('Z');
+        expect(capitalTwo).toBeInTheDocument();
+        fireEvent.click(capitalTwo);
+        expect(await screen.findByRole('textbox')).toHaveValue('AZ')
+      });
+      describe('Pressing Shift afterwards', function () {
+        beforeEach(function() {
+          fireEvent.click(screen.getAllByText('shift')[0]);
+        });
+        it('Should make the characters in the keyboard lowercase', async function () {
+          const lowercase = await screen.findByText('z');
+          expect(lowercase).toBeInTheDocument();
+          const capital = screen.queryByText('A');
+          expect(capital).not.toBeInTheDocument();
+        });
+        it('Should revert to uppercase after the next character is pressed', async function () {
+          const lowercase = await screen.findByText('z');
+          fireEvent.click(lowercase);
+          expect(screen.getByRole('textbox')).toHaveValue('z')
+          const capital = await screen.findByText('A');
+          expect(lowercase).not.toBeInTheDocument();
+          expect(capital).toBeInTheDocument();
+          fireEvent.click(capital);
+          expect(screen.getByRole('textbox')).toHaveValue('zA');
+          expect(capital).toBeInTheDocument();
+        });
+      });
+      describe('Pressing Caps Lock again', function () {
+        beforeEach(function () {
+          fireEvent.click(screen.getByText('caps'));
+        });
+        it('Should revert to lowercase', async function () {
+          const lowercase = await screen.findByText('z')
+          expect(lowercase).toBeInTheDocument(); 
+          const capital = screen.queryByText('A');
+          expect(capital).not.toBeInTheDocument(); 
+        });
+      });
+    });
+  });
+});

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -135,7 +135,7 @@ const keyboardModalRef = useRef<HTMLDivElement>(null);
               type="text" 
               className="keyboard--search-input"
               placeholder="Search for a person or place"
-              value={searchQuery}
+              defaultValue={searchQuery}
             />
           </div>
           <div className="keyboard--keyboard-container">

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -3,7 +3,7 @@ import 'react-simple-keyboard/build/css/index.css';
 import './Keyboard.css';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import {DISPLAY_WIDTH, DISPLAY_HEIGHT } from '../const/display';
+import { DISPLAY_WIDTH, DISPLAY_HEIGHT } from '../const/display';
 
 interface OnScreenKeyboardProps {
   /**
@@ -65,10 +65,10 @@ const OnScreenKeyboard = ({
       const background = backdropRef.current;
       const closeKeyboard = (evt: MouseEvent) => {
         if (evt.target === background) {
-          searchUpdateHandler('')
+          searchUpdateHandler('');
           setVisible(false);
-        };
-      }
+        }
+      };
       if (background) {
         background.addEventListener('click', closeKeyboard);
       }
@@ -76,7 +76,7 @@ const OnScreenKeyboard = ({
         if (background) {
            background.removeEventListener('click', closeKeyboard);
         }
-      })
+      });
     }
     const openKeyboard = (evt: MouseEvent) => {
       setVisible(true);
@@ -91,7 +91,7 @@ const OnScreenKeyboard = ({
     setVisible,
     setCoordinates,
     backdropRef,
-    searchUpdateHandler
+    searchUpdateHandler,
   ]);
 
   /**
@@ -177,7 +177,7 @@ const OnScreenKeyboard = ({
       const topPosition = Math.min(
         Math.max(0, topEdge),
         DISPLAY_HEIGHT - keyboardHeight
-      )
+      );
       modal.style.left = `${leftPosition}px`;
       modal.style.top = `${topPosition}px`;
     }

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -1,0 +1,108 @@
+import Keyboard from 'react-simple-keyboard';
+import 'react-simple-keyboard/build/css/index.css';
+import './Keyboard.css';
+import { useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {DISPLAY_WIDTH, DISPLAY_HEIGHT } from '../const/display';
+
+interface OnScreenKeyboardProps {
+  /**
+   * The text that's currently being searched
+   */
+  searchQuery: string;
+  /**
+   * A handler to update the search text
+   */
+  searchUpdateHandler: (arg0: string) => void;
+  /**
+   * A handler to initiate a search
+   */
+  triggerSearchHandler: () => void;
+}
+
+const OnScreenKeyboard = ({
+  searchQuery,
+  searchUpdateHandler,
+  triggerSearchHandler,
+}: OnScreenKeyboardProps) => {
+  /**
+   * Whether the keyboard should be shown on screen
+   */
+  const [isVisible, setVisible] = useState(true);
+
+  /**
+   * The X,Y coordinates on the page at which the keyboard should be rendered
+   */
+  const [coordinates, setCoordinates] = useState<[number, number]>([540, 960]);
+
+const keyboardModalRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const modal = keyboardModalRef.current;
+    const [xTap, yTap] = coordinates;
+    if (isVisible && modal !== null) {
+      const keyboardWidth = modal.clientWidth;
+      const keyboardHeight = modal.clientHeight;
+      // Make sure that the tap position coordinates wouldn't render the keyboard outside the screen
+      const leftEdge = xTap - keyboardWidth/2;
+      const topEdge = yTap - keyboardHeight/2;
+      const leftPosition = Math.min(
+        Math.max(0, leftEdge),
+        DISPLAY_WIDTH - keyboardWidth
+      );
+      const topPosition = Math.min(
+        Math.max(0, topEdge),
+        DISPLAY_HEIGHT - keyboardHeight
+      )
+      modal.style.left = `${leftPosition}px`;
+      modal.style.top = `${topPosition}px`;
+    }
+  }, [isVisible, coordinates, keyboardModalRef]);
+
+  if (isVisible) {
+    return createPortal((
+      <div className="keyboard--backdrop">
+        <div className="keyboard--modal" ref={keyboardModalRef}>
+          <div className="keyboard--search-container">
+            <label 
+              className="keyboard--search-input-label"
+              htmlFor="search-query"
+            >
+              Search Query
+            </label>
+            <input 
+              name="search-query" 
+              type="text" 
+              className="keyboard--search-input"
+              placeholder="Search for a person or place"
+              value={searchQuery}
+            />
+          </div>
+          <div className="keyboard--keyboard-container">
+            <Keyboard
+              onChange={searchUpdateHandler}
+              layoutName="shift"
+            />
+          </div>
+          <div className="keyboard--buttons">
+            <button
+              className="keyboard--cancel-button"
+              onClick={() => {setVisible(false)}}
+            >
+              cancel
+            </button>
+            <button
+              className="keyboard--search-button"
+              onClick={triggerSearchHandler}
+            >
+              search 
+            </button>
+          </div>
+        </div>
+      </div>
+    ), document.body);
+  }
+  return null;
+};
+
+export default OnScreenKeyboard;

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -54,7 +54,9 @@ const OnScreenKeyboard = ({
    * The X,Y coordinates on the page at which the center point of the keyboard
    * should be rendered
    */
-  const [coordinates, setCoordinates] = useState<[number, number]>([540, 960]);
+  const [coordinates, setCoordinates] = useState<[number, number]>(
+    [DISPLAY_WIDTH/2, DISPLAY_HEIGHT/2]
+  );
 
   /**
    * Handle setting the event listener to open the keyboard when clicking on

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -82,6 +82,8 @@ const keyboardModalRef = useRef<HTMLDivElement>(null);
             <Keyboard
               onChange={searchUpdateHandler}
               layoutName="shift"
+              theme="hg-theme-default hg-layout-default keyboard--component"
+              useButtonTag
             />
           </div>
           <div className="keyboard--buttons">

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -20,6 +20,21 @@ interface OnScreenKeyboardProps {
   triggerSearchHandler: () => void;
 }
 
+
+/**
+* Enum for handling the casing of the keyboard
+*/
+enum CASE {
+  /** lowercase layout */
+  DEFAULT,
+  /** next character uppercase, then back to lowercase */
+  SHIFTED,
+  /** uppercase layout */
+  LOCKED,
+  /** next character lowercase, then back to uppercase */
+  UNSHIFTED,
+}
+
 const OnScreenKeyboard = ({
   searchQuery,
   searchUpdateHandler,
@@ -36,6 +51,51 @@ const OnScreenKeyboard = ({
   const [coordinates, setCoordinates] = useState<[number, number]>([540, 960]);
 
 const keyboardModalRef = useRef<HTMLDivElement>(null);
+
+  const otherKeyHandler = (button: string) => {
+    setKeyboardCase((currentCase) => {
+      switch(currentCase) {
+        case CASE.DEFAULT: {
+          if (button === '{shift}') {
+            return CASE.SHIFTED;
+          }
+          if (button === '{lock}') {
+            return CASE.LOCKED;
+          }
+          return CASE.DEFAULT;
+        }
+        case CASE.SHIFTED: {
+          if (button === '{shift}') {
+            return CASE.DEFAULT;
+          }
+          if (button === '{lock}') {
+            return CASE.LOCKED;
+          }
+          return CASE.DEFAULT;
+        }
+        case CASE.UNSHIFTED: {
+          if (button === '{shift}') {
+            return CASE.LOCKED;
+          }
+          if (button === '{lock}') {
+            return CASE.DEFAULT;
+          }
+          return CASE.LOCKED;
+        }
+        case CASE.LOCKED: {
+          if (button === '{shift}') {
+            return CASE.UNSHIFTED;
+          }
+          if (button === '{lock}') {
+            return CASE.DEFAULT;
+          }
+          return CASE.LOCKED;
+        }
+        default:
+          return currentCase;
+      }
+    });
+  };
 
   useLayoutEffect(() => {
     const modal = keyboardModalRef.current;
@@ -81,7 +141,12 @@ const keyboardModalRef = useRef<HTMLDivElement>(null);
           <div className="keyboard--keyboard-container">
             <Keyboard
               onChange={searchUpdateHandler}
-              layoutName="shift"
+              onKeyPress={otherKeyHandler}
+              layoutName={
+                [CASE.LOCKED, CASE.SHIFTED].includes(keyboardCase)
+                  ? 'shift'
+                  : 'default'
+              }
               theme="hg-theme-default hg-layout-default keyboard--component"
               useButtonTag
             />

--- a/src/const/display.ts
+++ b/src/const/display.ts
@@ -1,0 +1,3 @@
+export const DISPLAY_WIDTH = 1080;
+
+export const DISPLAY_HEIGHT = 1920;


### PR DESCRIPTION
Despite my initial efforts to limit this to just setting up the keyboard, I kind of wound up implementing all of the features specified in #9, #10, #11, and #12 in this single PR, as there were so many interdependencies and overalpping functionality. So sorry this is a bit longer than expected.

The React Keyboard  library itself was easy enough to plug in, but it needed a couple of tweaks for things like custom styling, showing the current value above it, and handling shift/caps functionality (which, curiously, is not built in). I still think we'll want to tweak the actual keys displayed on the keyboard at some point in the future, but having extra buttons shouldn't break anything for the time being.

Just to recap the expected functionality:

- When initially loading the page the keyboard is hidden
- Once you tap/click on the screen the keyboard will appear, centered on the position that was tapped (without rendering outside the screen)
- The keyboard will disappear when you:
  1. Tap/click outside the keyboard window
  2. Tap/click the cancel/search buttons
  3. Tap/click the enter key

I did not get a chance to test this on the big display at 114, but I'll try to get that plugged in next time I'm there.

Screenshots of keyboard in multiple positions:

![Screen Shot 2021-08-17 at 08 49 44](https://user-images.githubusercontent.com/6124793/129729087-9e704ce6-6f59-4c7d-818c-ed72640281fa.png)
![Screen Shot 2021-08-17 at 08 49 40](https://user-images.githubusercontent.com/6124793/129729096-01064b54-474e-4260-b4c6-8282c4e7c3d1.png)
![Screen Shot 2021-08-17 at 08 49 35](https://user-images.githubusercontent.com/6124793/129729097-a206d91b-9c55-45ac-9fe8-61f6d4a9178f.png)



fixes #9
fixes #10
fixes #11
fixes #12
