### PR TITLE
Initialize Algolia Search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,131 @@
         "@types/node": "^12.20.19",
         "@types/react": "^17.0.17",
         "@types/react-dom": "^17.0.9",
+        "algoliasearch": "^4.10.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-instantsearch-dom": "^6.12.1",
         "react-scripts": "4.0.3",
         "react-simple-keyboard": "^3.2.50",
         "typescript": "^4.3.5"
+      },
+      "devDependencies": {
+        "@types/react-instantsearch-dom": "^6.12.0"
+      }
+    },
+    "node_modules/@algolia/cache-browser-local-storage": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.3.tgz",
+      "integrity": "sha512-TD1N7zg5lb56/PLjjD4bBl2eccEvVHhC7yfgFu2r9k5tf+gvbGxEZ3NhRZVKu2MObUIcEy2VR4LVLxOQu45Hlg==",
+      "dependencies": {
+        "@algolia/cache-common": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/cache-common": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.3.tgz",
+      "integrity": "sha512-q13cPPUmtf8a2suBC4kySSr97EyulSXuxUkn7l1tZUCX/k1y5KNheMp8npBy8Kc8gPPmHpacxddRSfOncjiKFw=="
+    },
+    "node_modules/@algolia/cache-in-memory": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.3.tgz",
+      "integrity": "sha512-JhPajhOXAjUP+TZrZTh6KJpF5VKTKyWK2aR1cD8NtrcVHwfGS7fTyfXfVm5BqBqkD9U0gVvufUt/mVyI80aZww==",
+      "dependencies": {
+        "@algolia/cache-common": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/client-account": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.3.tgz",
+      "integrity": "sha512-S/IsJB4s+e1xYctdpW3nAbwrR2y3pjSo9X21fJGoiGeIpTRdvQG7nydgsLkhnhcgAdLnmqBapYyAqMGmlcyOkg==",
+      "dependencies": {
+        "@algolia/client-common": "4.10.3",
+        "@algolia/client-search": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.3.tgz",
+      "integrity": "sha512-vlHTbBqJktRgclh3v7bPQLfZvFIqY4erNFIZA5C7nisCj9oLeTgzefoUrr+R90+I+XjfoLxnmoeigS1Z1yg1vw==",
+      "dependencies": {
+        "@algolia/client-common": "4.10.3",
+        "@algolia/client-search": "4.10.3",
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.3.tgz",
+      "integrity": "sha512-uFyP2Z14jG2hsFRbAoavna6oJf4NTXaSDAZgouZUZlHlBp5elM38sjNeA5HR9/D9J/GjwaB1SgB7iUiIWYBB4w==",
+      "dependencies": {
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.3.tgz",
+      "integrity": "sha512-NS7Nx8EJ/nduGXT8CFo5z7kLF0jnFehTP3eC+z+GOEESH3rrs7uR12IZHxv5QhQswZa9vl925zCOZDcDVoENCg==",
+      "dependencies": {
+        "@algolia/client-common": "4.10.3",
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.3.tgz",
+      "integrity": "sha512-Zwnp2G94IrNFKWCG/k7epI5UswRkPvL9FCt7/slXe2bkjP2y/HA37gzRn+9tXoLVRwd7gBzrtOA4jFKIyjrtVw==",
+      "dependencies": {
+        "@algolia/client-common": "4.10.3",
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/logger-common": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.3.tgz",
+      "integrity": "sha512-M6xi+qov2bkgg1H9e1Qtvq/E/eKsGcgz8RBbXNzqPIYoDGZNkv+b3b8YMo3dxd4Wd6M24HU1iqF3kmr1LaXndg=="
+    },
+    "node_modules/@algolia/logger-console": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.3.tgz",
+      "integrity": "sha512-vVgRI7b4PHjgBdRkv/cRz490twvkLoGdpC4VYzIouSrKj8SIVLRhey3qgXk7oQXi3xoxVAv6NrklHfpO8Bpx0w==",
+      "dependencies": {
+        "@algolia/logger-common": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.3.tgz",
+      "integrity": "sha512-4WIk1zreFbc1EF6+gsfBTQvwSNjWc20zJAAExRWql/Jq5yfVHmwOqi/CajA53/cXKFBqo80DAMRvOiwP+hOLYw==",
+      "dependencies": {
+        "@algolia/requester-common": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/requester-common": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.3.tgz",
+      "integrity": "sha512-PNfLHmg0Hujugs3rx55uz/ifv7b9HVdSFQDb2hj0O5xZaBEuQCNOXC6COrXR8+9VEfqp2swpg7zwgtqFxh+BtQ=="
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.3.tgz",
+      "integrity": "sha512-A9ZcGfEvgqf0luJApdNcIhsRh6MShn2zn2tbjwjGG1joF81w+HUY+BWuLZn56vGwAA9ZB9n00IoJJpxibbfofg==",
+      "dependencies": {
+        "@algolia/requester-common": "4.10.3"
+      }
+    },
+    "node_modules/@algolia/transporter": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.3.tgz",
+      "integrity": "sha512-n1lRyKDbrckbMEgm7QXtj3nEWUuzA3aKLzVQ43/F/RCFib15j4IwtmYhXR6OIBRSc7+T0Hm48S0J6F+HeYCQkw==",
+      "dependencies": {
+        "@algolia/cache-common": "4.10.3",
+        "@algolia/logger-common": "4.10.3",
+        "@algolia/requester-common": "4.10.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3551,6 +3671,27 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-instantsearch-core": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@types/react-instantsearch-core/-/react-instantsearch-core-6.10.4.tgz",
+      "integrity": "sha512-Qdc7h2bkXaVljbNL2wg0hRLN7FLTi7NeaD+VLvjF8A5M41olgEIIzdoDye+OfiB/COk4ynXbw0bqxhhNUA6gxw==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*",
+        "algoliasearch": ">=4",
+        "algoliasearch-helper": ">=3"
+      }
+    },
+    "node_modules/@types/react-instantsearch-dom": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@types/react-instantsearch-dom/-/react-instantsearch-dom-6.12.0.tgz",
+      "integrity": "sha512-O08H+ye4e4kEnYHmMrov9FPNRDJwfCWthNZf4aztqahpU8LSbAiuFQGVy84SHUvg/jfNcG4333SsVnAQLtbS7A==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*",
+        "@types/react-instantsearch-core": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
@@ -4124,6 +4265,46 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "peerDependencies": {
         "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.3.tgz",
+      "integrity": "sha512-OLY0AWlPKGLbSaw14ivMB7BT5fPdp8VdzY4L8FtzZnqmLKsyes24cltGlf7/X96ACkYEcT390SReCDt/9SUIRg==",
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.10.3",
+        "@algolia/cache-common": "4.10.3",
+        "@algolia/cache-in-memory": "4.10.3",
+        "@algolia/client-account": "4.10.3",
+        "@algolia/client-analytics": "4.10.3",
+        "@algolia/client-common": "4.10.3",
+        "@algolia/client-personalization": "4.10.3",
+        "@algolia/client-search": "4.10.3",
+        "@algolia/logger-common": "4.10.3",
+        "@algolia/logger-console": "4.10.3",
+        "@algolia/requester-browser-xhr": "4.10.3",
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/requester-node-http": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "node_modules/algoliasearch-helper": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz",
+      "integrity": "sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==",
+      "dependencies": {
+        "events": "^1.1.1"
+      },
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 5"
+      }
+    },
+    "node_modules/algoliasearch-helper/node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/alphanum-sort": {
@@ -5795,6 +5976,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "node_modules/clean-css": {
       "version": "4.2.3",
@@ -16395,6 +16581,43 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "node_modules/react-instantsearch-core": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.12.1.tgz",
+      "integrity": "sha512-X4OqakDI3DOcFiS1S46z+cciKEQcKBmH8HGQLztzW14hoHRqFfZzuqWydlSxfJZN5WksMMm78EmL2jvoqIHd/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "algoliasearch-helper": "^3.5.3",
+        "prop-types": "^15.6.2",
+        "react-fast-compare": "^3.0.0"
+      },
+      "peerDependencies": {
+        "algoliasearch": ">= 3.1 < 5",
+        "react": ">= 16.3.0 < 18"
+      }
+    },
+    "node_modules/react-instantsearch-dom": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.12.1.tgz",
+      "integrity": "sha512-KXk2UDmJ3OP9B57owPC0+7fdcVtmYAA6/UWimR9CXhvFGCMi11xlR/wscYMYxdPuxs9IkmnnLDIJSjSGADYnow==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "algoliasearch-helper": "^3.5.3",
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.2",
+        "react-fast-compare": "^3.0.0",
+        "react-instantsearch-core": "^6.12.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0 < 18",
+        "react-dom": ">= 16.3.0 < 18"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -21643,6 +21866,121 @@
     }
   },
   "dependencies": {
+    "@algolia/cache-browser-local-storage": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.3.tgz",
+      "integrity": "sha512-TD1N7zg5lb56/PLjjD4bBl2eccEvVHhC7yfgFu2r9k5tf+gvbGxEZ3NhRZVKu2MObUIcEy2VR4LVLxOQu45Hlg==",
+      "requires": {
+        "@algolia/cache-common": "4.10.3"
+      }
+    },
+    "@algolia/cache-common": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.3.tgz",
+      "integrity": "sha512-q13cPPUmtf8a2suBC4kySSr97EyulSXuxUkn7l1tZUCX/k1y5KNheMp8npBy8Kc8gPPmHpacxddRSfOncjiKFw=="
+    },
+    "@algolia/cache-in-memory": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.3.tgz",
+      "integrity": "sha512-JhPajhOXAjUP+TZrZTh6KJpF5VKTKyWK2aR1cD8NtrcVHwfGS7fTyfXfVm5BqBqkD9U0gVvufUt/mVyI80aZww==",
+      "requires": {
+        "@algolia/cache-common": "4.10.3"
+      }
+    },
+    "@algolia/client-account": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.3.tgz",
+      "integrity": "sha512-S/IsJB4s+e1xYctdpW3nAbwrR2y3pjSo9X21fJGoiGeIpTRdvQG7nydgsLkhnhcgAdLnmqBapYyAqMGmlcyOkg==",
+      "requires": {
+        "@algolia/client-common": "4.10.3",
+        "@algolia/client-search": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "@algolia/client-analytics": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.3.tgz",
+      "integrity": "sha512-vlHTbBqJktRgclh3v7bPQLfZvFIqY4erNFIZA5C7nisCj9oLeTgzefoUrr+R90+I+XjfoLxnmoeigS1Z1yg1vw==",
+      "requires": {
+        "@algolia/client-common": "4.10.3",
+        "@algolia/client-search": "4.10.3",
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "@algolia/client-common": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.3.tgz",
+      "integrity": "sha512-uFyP2Z14jG2hsFRbAoavna6oJf4NTXaSDAZgouZUZlHlBp5elM38sjNeA5HR9/D9J/GjwaB1SgB7iUiIWYBB4w==",
+      "requires": {
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "@algolia/client-personalization": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.3.tgz",
+      "integrity": "sha512-NS7Nx8EJ/nduGXT8CFo5z7kLF0jnFehTP3eC+z+GOEESH3rrs7uR12IZHxv5QhQswZa9vl925zCOZDcDVoENCg==",
+      "requires": {
+        "@algolia/client-common": "4.10.3",
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "@algolia/client-search": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.3.tgz",
+      "integrity": "sha512-Zwnp2G94IrNFKWCG/k7epI5UswRkPvL9FCt7/slXe2bkjP2y/HA37gzRn+9tXoLVRwd7gBzrtOA4jFKIyjrtVw==",
+      "requires": {
+        "@algolia/client-common": "4.10.3",
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "@algolia/logger-common": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.3.tgz",
+      "integrity": "sha512-M6xi+qov2bkgg1H9e1Qtvq/E/eKsGcgz8RBbXNzqPIYoDGZNkv+b3b8YMo3dxd4Wd6M24HU1iqF3kmr1LaXndg=="
+    },
+    "@algolia/logger-console": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.3.tgz",
+      "integrity": "sha512-vVgRI7b4PHjgBdRkv/cRz490twvkLoGdpC4VYzIouSrKj8SIVLRhey3qgXk7oQXi3xoxVAv6NrklHfpO8Bpx0w==",
+      "requires": {
+        "@algolia/logger-common": "4.10.3"
+      }
+    },
+    "@algolia/requester-browser-xhr": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.3.tgz",
+      "integrity": "sha512-4WIk1zreFbc1EF6+gsfBTQvwSNjWc20zJAAExRWql/Jq5yfVHmwOqi/CajA53/cXKFBqo80DAMRvOiwP+hOLYw==",
+      "requires": {
+        "@algolia/requester-common": "4.10.3"
+      }
+    },
+    "@algolia/requester-common": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.3.tgz",
+      "integrity": "sha512-PNfLHmg0Hujugs3rx55uz/ifv7b9HVdSFQDb2hj0O5xZaBEuQCNOXC6COrXR8+9VEfqp2swpg7zwgtqFxh+BtQ=="
+    },
+    "@algolia/requester-node-http": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.3.tgz",
+      "integrity": "sha512-A9ZcGfEvgqf0luJApdNcIhsRh6MShn2zn2tbjwjGG1joF81w+HUY+BWuLZn56vGwAA9ZB9n00IoJJpxibbfofg==",
+      "requires": {
+        "@algolia/requester-common": "4.10.3"
+      }
+    },
+    "@algolia/transporter": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.3.tgz",
+      "integrity": "sha512-n1lRyKDbrckbMEgm7QXtj3nEWUuzA3aKLzVQ43/F/RCFib15j4IwtmYhXR6OIBRSc7+T0Hm48S0J6F+HeYCQkw==",
+      "requires": {
+        "@algolia/cache-common": "4.10.3",
+        "@algolia/logger-common": "4.10.3",
+        "@algolia/requester-common": "4.10.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -24148,6 +24486,27 @@
         "@types/react": "*"
       }
     },
+    "@types/react-instantsearch-core": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@types/react-instantsearch-core/-/react-instantsearch-core-6.10.4.tgz",
+      "integrity": "sha512-Qdc7h2bkXaVljbNL2wg0hRLN7FLTi7NeaD+VLvjF8A5M41olgEIIzdoDye+OfiB/COk4ynXbw0bqxhhNUA6gxw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "algoliasearch": ">=4",
+        "algoliasearch-helper": ">=3"
+      }
+    },
+    "@types/react-instantsearch-dom": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@types/react-instantsearch-dom/-/react-instantsearch-dom-6.12.0.tgz",
+      "integrity": "sha512-O08H+ye4e4kEnYHmMrov9FPNRDJwfCWthNZf4aztqahpU8LSbAiuFQGVy84SHUvg/jfNcG4333SsVnAQLtbS7A==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "@types/react-instantsearch-core": "*"
+      }
+    },
     "@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
@@ -24603,6 +24962,42 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "requires": {}
+    },
+    "algoliasearch": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.3.tgz",
+      "integrity": "sha512-OLY0AWlPKGLbSaw14ivMB7BT5fPdp8VdzY4L8FtzZnqmLKsyes24cltGlf7/X96ACkYEcT390SReCDt/9SUIRg==",
+      "requires": {
+        "@algolia/cache-browser-local-storage": "4.10.3",
+        "@algolia/cache-common": "4.10.3",
+        "@algolia/cache-in-memory": "4.10.3",
+        "@algolia/client-account": "4.10.3",
+        "@algolia/client-analytics": "4.10.3",
+        "@algolia/client-common": "4.10.3",
+        "@algolia/client-personalization": "4.10.3",
+        "@algolia/client-search": "4.10.3",
+        "@algolia/logger-common": "4.10.3",
+        "@algolia/logger-console": "4.10.3",
+        "@algolia/requester-browser-xhr": "4.10.3",
+        "@algolia/requester-common": "4.10.3",
+        "@algolia/requester-node-http": "4.10.3",
+        "@algolia/transporter": "4.10.3"
+      }
+    },
+    "algoliasearch-helper": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz",
+      "integrity": "sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==",
+      "requires": {
+        "events": "^1.1.1"
+      },
+      "dependencies": {
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        }
+      }
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -25927,6 +26322,11 @@
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
         }
       }
+    },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -34054,6 +34454,35 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "react-instantsearch-core": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.12.1.tgz",
+      "integrity": "sha512-X4OqakDI3DOcFiS1S46z+cciKEQcKBmH8HGQLztzW14hoHRqFfZzuqWydlSxfJZN5WksMMm78EmL2jvoqIHd/A==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "algoliasearch-helper": "^3.5.3",
+        "prop-types": "^15.6.2",
+        "react-fast-compare": "^3.0.0"
+      }
+    },
+    "react-instantsearch-dom": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.12.1.tgz",
+      "integrity": "sha512-KXk2UDmJ3OP9B57owPC0+7fdcVtmYAA6/UWimR9CXhvFGCMi11xlR/wscYMYxdPuxs9IkmnnLDIJSjSGADYnow==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "algoliasearch-helper": "^3.5.3",
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.2",
+        "react-fast-compare": "^3.0.0",
+        "react-instantsearch-core": "^6.12.1"
+      }
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "@types/node": "^12.20.19",
     "@types/react": "^17.0.17",
     "@types/react-dom": "^17.0.9",
+    "algoliasearch": "^4.10.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-instantsearch-dom": "^6.12.1",
     "react-scripts": "4.0.3",
     "react-simple-keyboard": "^3.2.50",
     "typescript": "^4.3.5"
@@ -39,5 +41,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/react-instantsearch-dom": "^6.12.0"
   }
 }

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -4,6 +4,7 @@ import Footer from '../Footer';
 import Main from '../Main';
 import { useEffect, useRef, useState } from 'react';
 import Welcome from '../Welcome';
+import SearchResults from '../Search';
 import OnScreenKeyboard from '../Keyboard';
 import {
   VIEW,
@@ -106,6 +107,11 @@ const App = () => {
           <Welcome bannerText={WELCOME_BANNER}>
             {WELCOME_INSTRUCTIONS}
           </Welcome>
+        )}
+        {currentView === VIEW.RESULTS && (
+          <SearchResults
+            searchQuery={searchInput}
+          />
         )}
         <OnScreenKeyboard
           backdropRef={keyboardBackgroundRef}

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -2,11 +2,13 @@ import './App.css';
 import Header from '../Header';
 import Footer from '../Footer';
 import Main from '../Main';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Welcome from '../Welcome';
 import OnScreenKeyboard from '../Keyboard';
 import {
   VIEW,
+  DISPLAY_WIDTH,
+  DISPLAY_HEIGHT,
   APP_NAME,
   WELCOME_BANNER,
   WELCOME_INSTRUCTIONS,
@@ -14,11 +16,72 @@ import {
 } from '../const';
 
 const App = () => {
+  /**
+   * The current value to search for
+   */
   const [searchInput, setSearchInput] = useState('');
 
+  /**
+   * Whether the keyboard should be displayed
+   */
   const [isKeyboardVisible, setKeyboardVisible] = useState(false);
 
-  const [currentView] = useState<VIEW>(VIEW.WELCOME);
+  /**
+   * The content that should be shown in the Main section
+   */
+  const [currentView, setView] = useState<VIEW>(VIEW.WELCOME);
+
+  /**
+   * A reference to the background div, used for adding/removing event handlers
+   */
+  const keyboardBackgroundRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * The X,Y coordinates on the page at which the center point of the keyboard
+   * should be rendered
+   */
+  const [keyboardCoordinates, setKeyboardCoordinates] = useState<[number, number]>(
+    [DISPLAY_WIDTH/2, DISPLAY_HEIGHT/2]
+  );
+
+  /**
+   * Handle setting the event listener to open the keyboard when clicking on
+   * the body, then close it when clicking outside the modal
+   */
+  useEffect(() => {
+    if (isKeyboardVisible) {
+      const background = keyboardBackgroundRef.current;
+      const closeKeyboard = (evt: MouseEvent) => {
+        if (evt.target === background) {
+          setKeyboardVisible(false);
+        }
+      };
+      if (background) {
+        background.addEventListener('click', closeKeyboard);
+      }
+      return(() => {
+        if (background) {
+          background.removeEventListener('click', closeKeyboard);
+        }
+      });
+    }
+    const openKeyboard = (evt: MouseEvent) => {
+      setSearchInput('');
+      setKeyboardVisible(true);
+      setKeyboardCoordinates([evt.clientX, evt.clientY]);
+      setView(VIEW.SEARCH);
+    };
+    document.body.addEventListener('click', openKeyboard);
+    return(() => {
+      document.body.removeEventListener('click', openKeyboard);
+    })
+  }, [
+    isKeyboardVisible,
+    setKeyboardVisible,
+    setKeyboardCoordinates,
+    keyboardBackgroundRef,
+    setSearchInput,
+  ]);
 
   /**
    * Reload the window if interval elapses with no activity
@@ -45,11 +108,19 @@ const App = () => {
           </Welcome>
         )}
         <OnScreenKeyboard
+          backdropRef={keyboardBackgroundRef}
+          coordinates={keyboardCoordinates}
           isVisible={isKeyboardVisible}
-          setVisible={setKeyboardVisible}
+          closeKeyboard={() => {
+            setKeyboardVisible(false)
+            setView(VIEW.WELCOME);
+          }}
           searchQuery={searchInput}
           searchUpdateHandler={setSearchInput}
-          triggerSearchHandler={() => {console.log(`SEARCH: ${searchInput}`)}}
+          triggerSearchHandler={() => {
+            setKeyboardVisible(false);
+            setView(VIEW.RESULTS)
+          }}
         /> 
       </Main>
       <Footer />

--- a/src/Keyboard/__tests__/Keyboard.test.tsx
+++ b/src/Keyboard/__tests__/Keyboard.test.tsx
@@ -1,34 +1,15 @@
 import { render, screen, fireEvent} from '@testing-library/react';
-import { useState } from 'react';
-import Keyboard from '..';
+import App from '../../App';
 
-
-const KeyboardTester = (
-  { searchHandler }: { searchHandler: () => void }
-) => {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [isVisible, setVisible] = useState(false);
-  return (
-    <div>
-      <Keyboard 
-        isVisible={isVisible}
-        setVisible={setVisible}
-        searchQuery={searchQuery}
-        searchUpdateHandler={setSearchQuery}
-        triggerSearchHandler={searchHandler}
-      />
-      <p>Click outside</p>
-    </div>);
-}
+// Mocks out a very basic version of the algolia searchClient
+jest.mock('algoliasearch/lite', () => () => ({
+  search: () => {return []},
+}));
 
 describe('Keyboard', function () {
-  let searchHandler: () => void;
-  beforeEach(function () {
-    searchHandler = jest.fn();
- });
   describe('Opening/Closing the keyboard', function () {
     beforeEach(function () {
-      render(<KeyboardTester searchHandler={searchHandler} />);
+      render(<App />);
     });
     describe('On initial render', function () {
       it('Should not initially appear', function () {
@@ -78,7 +59,7 @@ describe('Keyboard', function () {
   });
   describe('Input display', function () {
     beforeEach(function () {
-      render(<KeyboardTester searchHandler={searchHandler} />);
+      render(<App />);
       fireEvent.click(document.body);
     });
     it('Should display the text entered in the keys', function () {
@@ -91,7 +72,7 @@ describe('Keyboard', function () {
   });
   describe('Upper- and lower-case handling', function () {
     beforeEach(function () {
-      render(<KeyboardTester searchHandler={searchHandler} />)
+      render(<App />)
       fireEvent.click(document.body);
     });
     it('Should initially be lowercase', async function () {

--- a/src/Search/index.tsx
+++ b/src/Search/index.tsx
@@ -1,0 +1,47 @@
+import algoliasearch from 'algoliasearch/lite';
+import { useEffect } from 'react';
+import { InstantSearch, Hits, Configure, connectSearchBox } from 'react-instantsearch-dom';
+import { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX } from '../const';
+
+const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
+
+interface searchProps {
+  /** The text to search against algolia */
+  searchQuery: string;
+}
+
+/**
+* The InstantSearch library only runs the actual search when the refine
+* function in the SearchBox component is called, so we have a null version of
+* the SearchBox to handle that for us 
+*/
+
+const Query = connectSearchBox(
+  ({currentRefinement, refine}) => {
+  useEffect(() => {refine(currentRefinement)});
+  return null;
+});
+
+/**
+* Wrapper around the Algolia InstantSearch components that just runs the query
+* provided by the searchQuery prop and displays the results
+*/
+const Search = ({ searchQuery }: searchProps) => {
+  return (
+    <InstantSearch 
+      searchClient={searchClient}
+      indexName={ALGOLIA_INDEX}
+      refresh
+    >
+      <Query defaultRefinement={searchQuery} />
+      <Configure
+        hitsPerPage={8}
+        analytics={false}
+        enablePersonalization={false}
+        distinct
+      />
+        <Hits />
+    </InstantSearch>);
+}
+
+export default Search;

--- a/src/const/.gitignore
+++ b/src/const/.gitignore
@@ -1,0 +1,1 @@
+algolia.ts

--- a/src/const/algolia.example.ts
+++ b/src/const/algolia.example.ts
@@ -1,0 +1,3 @@
+export const ALGOLIA_API_KEY = '';
+export const ALGOLIA_APP_ID = ''
+export const ALGOLIA_INDEX = '';

--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -1,3 +1,4 @@
+export * from './algolia';
 export * from './display';
 export * from './text';
 export * from './time';

--- a/src/const/view.ts
+++ b/src/const/view.ts
@@ -4,4 +4,6 @@
  */
 export enum VIEW {
   WELCOME,
+  SEARCH,
+  RESULTS,
 };


### PR DESCRIPTION
This implements a very bare bones Algolia search component that takes in whatever the `searchInput` value is and dumps the JSON results into a list on the page. Getting this to work correctly did require moving more state up in the top-level component to make sure that the different `useEffect` calls were going off when they should.

In order to get this running locally, you'll need to create a `src/const/algolia.ts` file (based on the example included here) and populate it with the necessary values from the Algolia dashboard (or ping me and I'll send them to you). These aren't secure values, but by not hard-coding them into the repo and specifying them as part of the build process we can make sure we're using the correct ones for production.

One piece I'm still unsure on is what should happen _behind_ the keyboard if you re-open it after searching. I've set it up here to just blank out the `Main` area, but we could also leave the `SearchResults` page up, which would continuously update as the search query changes. That could be desirable, to help people narrow down a search, or it could just be distracting. For now, I'll leave it blank, and when we can test on the real screen we can revisit.