### PR TITLE
GitHub Actions: Test and Publish

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,6 +32,12 @@ jobs:
           node-version: 14
       - name: Install Dependencies
         run: npm install
+      - name: update patch version number
+        run: |
+          npm version patch -m "Automatic bump to %s"
+          echo "LATEST_TAG=$(jq -Mr .version package.json)" >> $GITHUB_ENV
+      - name: Push back to branch
+        run: git push --tags origin ${{ github.ref }}
       - name: Build bundle
         run: npm run build
       - name: Publish Artifact

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,7 +14,7 @@ jobs:
         # Pip and system dependencies needed inside the container
       - uses: actions/setup-node@v2
         with:
-          node_version: 14
+          node-version: 14
       - name: Install Dependencies
         run: npm install
       - name: Run Tests 
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node_version: 14
+          node-version: 14
       - name: Install Dependencies
         run: npm install
       - name: Build bundle

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -60,7 +60,7 @@ jobs:
             });
             const name = 'sec-directory-client.tar.gz';
             const data = fs.readFileSync('./sec-directory-client.tar.gz');
-            const github.rest.repos.uploadReleaseAsset({
+            await github.rest.repos.uploadReleaseAsset({
               owner,
               repo,
               release_id,

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,17 +32,15 @@ jobs:
           node-version: 14
       - name: Install Dependencies
         run: npm ci
-      - name: update patch version number
-        run: |
-          npm version patch -m "Automatic bump to %s"
-          echo "LATEST_TAG=$(jq -Mr .version package.json)" >> $GITHUB_ENV
-      - name: Push back to branch
+      - name: update patch version number and push back to branch
         run: |
           git config --local user.name "SEAS COMPUTING ROBOT"
           git config --local user.email "computing-dev-team@seas.harvard.edu"
           git config --local push.default matching
           git config credential.helper "store --file=.git/credentials"
           echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
+          npm version patch -m "Automatic bump to %s"
+          echo "LATEST_TAG=$(jq -Mr .version package.json)" >> $GITHUB_ENV
           git push --tags origin ${{ github.ref }}
       - name: Build bundle
         run: npm run build

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -40,7 +40,7 @@ jobs:
           git config credential.helper "store --file=.git/credentials"
           echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
           npm version patch -m "Automatic bump to %s"
-          echo "LATEST_TAG=$(jq -Mr .version package.json)" >> $GITHUB_ENV
+          echo "LATEST_TAG=v$(jq -Mr .version package.json)" >> $GITHUB_ENV
           git push --tags origin ${{ github.ref }}
       - name: Build bundle
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -53,14 +53,14 @@ jobs:
             const fs = require('fs');
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
             const tag = process.env.LATEST_TAG;
-            const { id: release_id } = await github.rest.repos.createRelease({
+            const { id: release_id } = await github.repos.createRelease({
               owner,
               repo,
               tag
             });
             const name = 'sec-directory-client.tar.gz';
             const data = fs.readFileSync('./sec-directory-client.tar.gz');
-            await github.rest.repos.uploadReleaseAsset({
+            await github.repos.uploadReleaseAsset({
               owner,
               repo,
               release_id,

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -52,11 +52,11 @@ jobs:
           script: |
             const fs = require('fs');
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-            const tag = process.env.LATEST_TAG;
+            const tag_name = process.env.LATEST_TAG;
             const { id: release_id } = await github.repos.createRelease({
               owner,
               repo,
-              tag
+              tag_name
             });
             const name = 'sec-directory-client.tar.gz';
             const data = fs.readFileSync('./sec-directory-client.tar.gz');

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -53,11 +53,13 @@ jobs:
             const fs = require('fs');
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
             const tag_name = process.env.LATEST_TAG;
-            const { id: release_id } = await github.repos.createRelease({
+            const newRelease = await github.repos.createRelease({
               owner,
               repo,
               tag_name
             });
+            core.debug(newRelease);
+            const { id: release_id } = newRelease;
             const name = 'sec-directory-client.tar.gz';
             const data = fs.readFileSync('./sec-directory-client.tar.gz');
             await github.repos.uploadReleaseAsset({

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -58,14 +58,15 @@ jobs:
               repo,
               tag_name
             });
-            core.debug(newRelease);
-            const { id: release_id } = newRelease;
-            const name = 'sec-directory-client.tar.gz';
+            const { data: { id: release_id, url } } = newRelease;
+            core.info(`Published ${tag_name}: ${url}`)
+            const name = `sec-directory-client_${tag_name}.tar.gz`;
             const data = fs.readFileSync('./sec-directory-client.tar.gz');
-            await github.repos.uploadReleaseAsset({
+            const { data: { url: asset_url } } =  await github.repos.uploadReleaseAsset({
               owner,
               repo,
               release_id,
               name,
               data,
             });
+            core.info(`Published ${name}: ${asset_url}`);

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -21,8 +21,8 @@ jobs:
         run: npm run test
   build:
     name: Build front end bundle 
-    # Only build container when code has been merged into main
-    # if: github.event_name == 'push' && github.ref == 'main'
+    # Only build bundle when code has been merged into main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -32,6 +32,9 @@ jobs:
           node-version: 14
       - name: Install Dependencies
         run: npm ci
+      # We need to log in as our robot account to attach a name/id to the
+      # commit, or else this step fails.  We're still using the token that
+      # GitHub Actions automatically generates
       - name: update patch version number and push back to branch
         run: |
           git config --local user.name "SEAS COMPUTING ROBOT"
@@ -46,6 +49,8 @@ jobs:
         run: |
           npm run build
           tar -czvf sec-directory-client.tar.gz build/*
+      # Runs a script to create a new release on github, matching the tag set
+      # above, and publish the built application as an asset on that release
       - name: Publish Bundle
         uses: actions/github-script@v4
         with:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -43,9 +43,27 @@ jobs:
           echo "LATEST_TAG=$(jq -Mr .version package.json)" >> $GITHUB_ENV
           git push --tags origin ${{ github.ref }}
       - name: Build bundle
-        run: npm run build
-      - name: Publish Artifact
-        uses: actions/upload-artifact@v2
+        run: |
+          npm run build
+          tar -czvf sec-directory-client.tar.gz build/*
+      - name: Publish Bundle
+        uses: actions/github-script@v4
         with:
-          name: sec-directory-client
-          path: build/
+          script: |
+            const fs = require('fs');
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+            const tag = process.env.LATEST_TAG;
+            const { id: release_id } = await github.rest.repos.createRelease({
+              owner,
+              repo,
+              tag
+            });
+            const name = 'sec-directory-client.tar.gz';
+            const data = fs.readFileSync('./sec-directory-client.tar.gz');
+            const github.rest.repos.uploadReleaseAsset({
+              owner,
+              repo,
+              release_id,
+              name,
+              data,
+            });

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,41 @@
+name: Test and Build
+# Runs on all pushes and PR's
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        # Pip and system dependencies needed inside the container
+      - uses: actions/setup-node@v2
+        with:
+          node_version: 14
+      - name: Install Dependencies
+        run: npm install
+      - name: Run Tests 
+        run: npm run test
+  build:
+    name: Build front end bundle 
+    # Only build container when code has been merged into main
+    # if: github.event_name == 'push' && github.ref == 'main'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node_version: 14
+      - name: Install Dependencies
+        run: npm install
+      - name: Build bundle
+        run: npm run build
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: sec-directory-client
+          path: build/

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -58,15 +58,15 @@ jobs:
               repo,
               tag_name
             });
-            const { data: { id: release_id, url } } = newRelease;
-            core.info(`Published ${tag_name}: ${url}`)
+            const { data: { id: release_id, html_url } } = newRelease;
+            core.info(`Published ${tag_name}: ${html_url}`)
             const name = `sec-directory-client_${tag_name}.tar.gz`;
             const data = fs.readFileSync('./sec-directory-client.tar.gz');
-            const { data: { url: asset_url } } =  await github.repos.uploadReleaseAsset({
+            const { data: { browser_download_url } } =  await github.repos.uploadReleaseAsset({
               owner,
               repo,
               release_id,
               name,
               data,
             });
-            core.info(`Published ${name}: ${asset_url}`);
+            core.info(`Published ${name}: ${browser_download_url}`);

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 14
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
       - name: Run Tests 
         run: npm run test
   build:
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: 14
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
       - name: update patch version number
         run: |
           npm version patch -m "Automatic bump to %s"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -37,7 +37,13 @@ jobs:
           npm version patch -m "Automatic bump to %s"
           echo "LATEST_TAG=$(jq -Mr .version package.json)" >> $GITHUB_ENV
       - name: Push back to branch
-        run: git push --tags origin ${{ github.ref }}
+        run: |
+          git config --local user.name "SEAS COMPUTING ROBOT"
+          git config --local user.email "computing-dev-team@seas.harvard.edu"
+          git config --local push.default matching
+          git config credential.helper "store --file=.git/credentials"
+          echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
+          git push --tags origin ${{ github.ref }}
       - name: Build bundle
         run: npm run build
       - name: Publish Artifact


### PR DESCRIPTION
This is broadly similar to the GitHub actions script in seas-computing/sec-directory-server#24, but it's publishing a `.tar.gz` file as a GitHub release instead of pushing a docker image to ghcr. Oddly, GitHub hasn't published their own "create-release" action like they have for many of the other GitHubby things one might do with actions, so we're using the `github-scripts` action. This just lets you write a script (in javascript) that has access to the GitHub API, which is straightforward enough to use for this sort of thing. 

I add that "enough" caveat because I did have to double-back and debug several things. As with the server side I've left those debugging commits in the history in case there illuminating for future use. I did, however, rebase out a bunch of commits that incremented the package version so that we didn't magically jump to `v0.0.11`, and removed all of the test tags/releases that were created along the way.

Fixes: #4
