### PR TITLE
Update project documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at seas-opensource@g.harvard.edu. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2021, President and Fellows of Harvard College. All rights
+reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The only outbound data connections are to Algolia, so the server project does no
 
 ### Development Index
 
-Ideally, each developer working on the project should create their own Algolia index (and corresponding API Key) to use while developing. You can use the same index for both client and server operations, though the server application does require an API key with write permission.
+Ideally, each developer working on the project should create their own Algolia index (and corresponding API Key) to use while developing. You can use the same index for both client and server operations, though the server application does require an API key with write permission. As noted above, you should use a [Secured API Key][api-key] and not an admin key.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](code-of-conduct.md)
 
+![BSD License](https://img.shields.io/github/license/seas-computing/mark-one)
+
 This is the react-based client application for the Directory Screen on the SEAS Allston Campus. It was bootstrapped with [Create React App][cra] using the default Typescript template.
 
 This is meant to be used in conjunction with the [sec-directory-server][server] project, which is responsible for populating the Algolia database.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The only outbound data connections are to Algolia, so the server project does no
 
 ### Testing
 
-`npm run test` Will run the Jest test suite. By default, jest will run in watch mode and re-run tests whenever the code changes on disk. For more information on Jest and its features, see [the project homepage][jest].
+`npm run test` will run the Jest test suite. By default, Jest will run in watch mode and re-run tests whenever the code changes on disk. For more information on Jest and its features, see [the project homepage][jest].
 
 For testing our front-end code, we're relying on [React Testing Library][rtl] and favoring behavior-based testing.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Test and Build](https://github.com/seas-computing/sec-directory-client/actions/workflows/test-build.yml/badge.svg)](https://github.com/seas-computing/sec-directory-client/actions/workflows/test-build.yml)
 
-This is the react-based client for the Directory Screen on the SEAS Allston Campus. It was bootstrapped with [Create React App][cra] using the default Typescript template.
+This is the react-based client application for the Directory Screen on the SEAS Allston Campus. It was bootstrapped with [Create React App][cra] using the default Typescript template.
+
+This is meant to be used in conjunction with the [sec-directory-server][server] project, which is responsible for populating the Algolia database.
 
 ## Setup
 
@@ -45,6 +47,7 @@ The official build of our code is handled by GitHub actions, and will be publish
 In production, the app will be server from an Amazon S3 bucket behind CloudFront.
 
 [cra]: https://create-react-app.dev/
+[server]: https://github.com/seas-computing/sec-directory-server
 [api-key]: https://www.algolia.com/doc/guides/security/api-keys/#secured-api-keys
 [planar]: https://www.planar.com/products/large-format-displays/ps4k/planar-ps5561t/
 [rdm]: https://developer.mozilla.org/en-US/docs/Tools/Responsive_Design_Mode

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SEC Directory Screens Client
 
+[![Test and Build](https://github.com/seas-computing/sec-directory-client/actions/workflows/test-build.yml/badge.svg)](https://github.com/seas-computing/sec-directory-client/actions/workflows/test-build.yml)
+
 This is the react-based client for the Directory Screen on the SEAS Allston Campus. It was bootstrapped with [Create React App][cra] using the default Typescript template.
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The backend of the application is the Algolia search index defined in the `REACT
 
 `npm run start` will bring up a live development environment with hot-reloading. Once it's started, you can view the app in the browser at http://localhost:3000/.
 
-As we're building for specific 55" touch screen displays ([Planar PS5561T][planar]) in portrait mode, the design of the page is fixed to a 1080x1920 rectangle with scrolling disabled. To view the application on a standard screen, you can use the [Responsive Design Mode][rdm] built into most browsers to emulate a 1080x1920 viewport.
+As we're building for specific 55" touch screen displays ([Planar PS5561T][planar]) in portrait mode, the design of the page is fixed to a 1080x1920 rectangle with scrolling and pinch-to-zoom disabled. To view the application on a standard screen, you can use the [Responsive Design Mode][rdm] built into most browsers to emulate a 1080x1920 viewport.
 
 The only outbound data connections are to Algolia, so the server project does not need to be running at the same time.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ This is the react-based client for the Directory Screen on the SEAS Allston Camp
 2. Run `npm install` to get all dependencies
 3. Copy `.env.example` to `.env` and populate with the desired Algolia details
 
+## Algolia
+
+The backend of the application is the Algolia search index defined in the `REACT_APP_ALGOLIA_INDEX`/`REACT_APP_ALGOLIA_APP_ID` environment variable. You'll also need to provide an API key in `REACT_APP_ALGOLIA_API_KEY`, which should only have "search" permissions for the specified index. **This API key will be included verbatim in the client code, so you should never use an admin key, or any key with write permission.** Best practice is [to create a "Secured API Key"][api-key] scoped only to the index you want to use.
+
+### Development Index
+
+Ideally, each developer working on the project should create their own Algolia index (and corresponding API Key) to use while developing. You can use the same index for both client and server operations, though the server application does require an API key with write permission.
+
+### Test Index
+
+You can optionally create a file called `.env.test` if you want to specify separate indices for testing and development. This is recommended, as some of the end-to-end tests defined in `src/__tests__/e2e.test.tsx` expect the index to include data.
+
 ## Local Development
 
 `npm run start` will bring up a live development environment with hot-reloading. Once it's started, you can view the app in the browser at http://localhost:3000/.
@@ -33,6 +45,7 @@ The official build of our code is handled by GitHub actions, and will be publish
 In production, the app will be server from an Amazon S3 bucket behind CloudFront.
 
 [cra]: https://create-react-app.dev/
+[api-key]: https://www.algolia.com/doc/guides/security/api-keys/#secured-api-keys
 [planar]: https://www.planar.com/products/large-format-displays/ps4k/planar-ps5561t/
 [rdm]: https://developer.mozilla.org/en-US/docs/Tools/Responsive_Design_Mode
 [jest]: https://jestjs.io/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # SEC Directory Screens Client
 
 [![Test and Build](https://github.com/seas-computing/sec-directory-client/actions/workflows/test-build.yml/badge.svg)](https://github.com/seas-computing/sec-directory-client/actions/workflows/test-build.yml)
-
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](code-of-conduct.md)
-
-![BSD License](https://img.shields.io/github/license/seas-computing/mark-one)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![BSD License](https://img.shields.io/github/license/seas-computing/mark-one)](LICENSE)
 
 This is the react-based client application for the Directory Screen on the SEAS Allston Campus. It was bootstrapped with [Create React App][cra] using the default Typescript template.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Test and Build](https://github.com/seas-computing/sec-directory-client/actions/workflows/test-build.yml/badge.svg)](https://github.com/seas-computing/sec-directory-client/actions/workflows/test-build.yml)
 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](code-of-conduct.md)
+
 This is the react-based client application for the Directory Screen on the SEAS Allston Campus. It was bootstrapped with [Create React App][cra] using the default Typescript template.
 
 This is meant to be used in conjunction with the [sec-directory-server][server] project, which is responsible for populating the Algolia database.

--- a/README.md
+++ b/README.md
@@ -10,12 +10,31 @@ This is the react-based client for the Directory Screen on the SEAS Allston Camp
 2. Run `npm install` to get all dependencies
 3. Copy `.env.example` to `.env` and populate with the desired Algolia details
 
-## Commands
+## Local Development
 
-`npm run start` - Bring up a live development environment
+`npm run start` will bring up a live development environment with hot-reloading. Once it's started, you can view the app in the browser at http://localhost:3000/.
 
-`npm run test` - Run jest test suite
+As we're building for specific 55" touch screen displays ([Planar PS5561T][planar]) in portrait mode, the design of the page is fixed to a 1080x1920 rectangle with scrolling disabled. To view the application on a standard screen, you can use the [Responsive Design Mode][rdm] built into most browsers to emulate a 1080x1920 viewport.
 
-`npm run build` - Create a production-ready bundle
+The only outbound data connections are to Algolia, so the server project does not need to be running at the same time.
+
+### Testing
+
+`npm run test` Will run the Jest test suite. By default, jest will run in watch mode and re-run tests whenever the code changes on disk. For more information on Jest and its features, see [the project homepage][jest].
+
+For testing our front-end code, we're relying on [React Testing Library][rtl] and favoring behavior-based testing.
+
+## Production Build
+
+`npm run build` will compile the full application in `/build`.
+
+The official build of our code is handled by GitHub actions, and will be published to the [releases section][releases] on every push to our main branch if all the tests pass.
+
+In production, the app will be server from an Amazon S3 bucket behind CloudFront.
 
 [cra]: https://create-react-app.dev/
+[planar]: https://www.planar.com/products/large-format-displays/ps4k/planar-ps5561t/
+[rdm]: https://developer.mozilla.org/en-US/docs/Tools/Responsive_Design_Mode
+[jest]: https://jestjs.io/
+[rtl]: https://testing-library.com/docs/react-testing-library/intro/
+[releases]: https://github.com/seas-computing/sec-directory-client/releases

--- a/README.md
+++ b/README.md
@@ -16,14 +16,6 @@ This is meant to be used in conjunction with the [sec-directory-server][server] 
 
 The backend of the application is the Algolia search index defined in the `REACT_APP_ALGOLIA_INDEX`/`REACT_APP_ALGOLIA_APP_ID` environment variable. You'll also need to provide an API key in `REACT_APP_ALGOLIA_API_KEY`, which should only have "search" permissions for the specified index. **This API key will be included verbatim in the client code, so you should never use an admin key, or any key with write permission.** Best practice is [to create a "Secured API Key"][api-key] scoped only to the index you want to use.
 
-### Development Index
-
-Ideally, each developer working on the project should create their own Algolia index (and corresponding API Key) to use while developing. You can use the same index for both client and server operations, though the server application does require an API key with write permission.
-
-### Test Index
-
-You can optionally create a file called `.env.test` if you want to specify separate indices for testing and development. This is recommended, as some of the end-to-end tests defined in `src/__tests__/e2e.test.tsx` expect the index to include data.
-
 ## Local Development
 
 `npm run start` will bring up a live development environment with hot-reloading. Once it's started, you can view the app in the browser at http://localhost:3000/.
@@ -32,11 +24,17 @@ As we're building for specific 55" touch screen displays ([Planar PS5561T][plana
 
 The only outbound data connections are to Algolia, so the server project does not need to be running at the same time.
 
-### Testing
+### Development Index
+
+Ideally, each developer working on the project should create their own Algolia index (and corresponding API Key) to use while developing. You can use the same index for both client and server operations, though the server application does require an API key with write permission.
+
+## Testing
 
 `npm run test` will run the Jest test suite. By default, Jest will run in watch mode and re-run tests whenever the code changes on disk. For more information on Jest and its features, see [the project homepage][jest].
 
-For testing our front-end code, we're relying on [React Testing Library][rtl] and favoring behavior-based testing.
+### Test Index
+
+You can optionally create a file called `.env.test` if you want to specify a separate index for testing. This is recommended, as some of the end-to-end tests defined in `src/__tests__/e2e.test.tsx` expect the index to include to include actual data, and keeping a separate test index can reduce phantom test failures.
 
 ## Production Build
 


### PR DESCRIPTION
This builds on the previous version of the `README` by providing more details about the individual components of the app, providing links to relevant external resources (including the `sec-directory-server` project) and making some recommendations about separating development and test indices.

I've also added our standard `CODE_OF_CONDUCT` document, as well as a copy of the BSD 3-clause license that we've used in the past. 

Most importantly, there are badges now.

Please let me know if you have any suggestions for other details that we should add to the README, of if there's anything here that's not totally clear. I know, the production section is definitely a little thin, but I expect we can add to that once we actually have a deployment out in the wild.