### PR TITLE
Tweak language on landing page

### DIFF
--- a/src/const/text.ts
+++ b/src/const/text.ts
@@ -10,10 +10,10 @@ export const APP_NAME = 'Allston Campus Directory';
 /**
  * The text that appears in the sub-heading on the initial welcome screen
  */
-export const WELCOME_BANNER = 'Welcome to Allston Campus';
+export const WELCOME_BANNER = 'Welcome to the Allston Campus';
 
 /**
  * The instructions for how to use the system which will be displayed on the
  * initial welcome screen
  */
-export const WELCOME_INSTRUCTIONS = 'Touch anywhere on this screen to search for SEAS offices, faculty and staff in the Allston Campus';
+export const WELCOME_INSTRUCTIONS = 'Touch anywhere on this screen to search for SEAS offices, faculty and staff on the Allston Campus';


### PR DESCRIPTION
This just makes two small tweaks to the landing page language, as requested by the communications team.

I also generated new screenshots showing the "Doyle" search flow, including the regex substitutions from seas-computing/sec-directory-server#34

![Screen Shot 2021-09-02 at 09 17 21](https://user-images.githubusercontent.com/6124793/131857015-a54553ee-0f87-4904-a0a4-eb30ad699292.png)

![Screen Shot 2021-09-02 at 09 17 31](https://user-images.githubusercontent.com/6124793/131857035-53a5a1f9-4101-45fc-a3c4-8202030fe5b8.png)


![Screen Shot 2021-09-02 at 09 55 08](https://user-images.githubusercontent.com/6124793/131857057-09f92f1b-4066-4c9a-9626-276192d52de7.png)
