### PR TITLE
Mitigate workflow collision issues

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,6 +27,7 @@ jobs:
     name: Build front end bundle 
     # Only build bundle when code has been merged into main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    concurrency: bump_build_release
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -31,7 +31,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      # Always check out the main branch
       - uses: actions/checkout@v2
+        with:
+          ref: refs/heads/main
       - uses: actions/setup-node@v2
         with:
           node-version: 14

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,13 +44,14 @@ jobs:
       # commit, or else this step fails.  We're still using the token that
       # GitHub Actions automatically generates
       - name: update patch version number and push back to branch
+        if: ${{ !startsWith(github.event.head_commit.message, '[release]') }}
         run: |
           git config --local user.name "SEAS COMPUTING ROBOT"
           git config --local user.email "computing-dev-team@seas.harvard.edu"
           git config --local push.default matching
           git config credential.helper "store --file=.git/credentials"
           echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
-          npm version patch -m "Automatic bump to %s"
+          npm version patch -m "[release] Automatic bump to %s"
           echo "LATEST_TAG=v$(jq -Mr .version package.json)" >> $GITHUB_ENV
           git push --tags origin ${{ github.ref }}
       - name: Build bundle


### PR DESCRIPTION
This PR makes a couple of small changes that should prevent, or at least reduce the impact of, the kind of workflow traffic jams we had when the last two PRs were merged. Each is introduced in a separate commit with additional explanation in the commit messages. The gist of it is:

1. Only one "Build" job will run at any one time
2. All "Build" jobs will run against the HEAD of `main`
3. We can prepend `[release]` to a commit to sidestep the version change

(That last one is mostly about appeasing my OCD when we make manual version changes, so we don't end up with `v1.0.1` instead of `v1.0.0`).

Unfortunately none of these change will really have an effect until this PR is merged. To test it though, I set up a [new repo under my username](https://github.com/jonseitz/sec-workflow-test), and then merged this same PR (jonseitz/sec-workflow-test#1) and a trivial PR (jonseitz/sec-workflow-test#2) at the same time. 

While the first build stage was running, this was shown in the workflow for the second:

![2021-09-09_124259](https://user-images.githubusercontent.com/6124793/132728498-37e2c917-ff11-4129-98ad-596760ae8e58.png)

Then when the second ran it bumped the version to `v0.0.7`, since the first had already bumped it to `v0.0.6`:

![2021-09-09_124426](https://user-images.githubusercontent.com/6124793/132728522-89e4f624-56b4-48bf-bf40-e20dc10852d0.png)

End result is that we got both `v0.0.6` and `v0.0.7` releases published:

![2021-09-09_124518](https://user-images.githubusercontent.com/6124793/132728540-b053a683-2a1d-4683-b118-22894f803690.png)

I should note though, that **both** of those releases built from the same code since they both checked out `main` **after** both had been merged:

![2021-09-09_125220](https://user-images.githubusercontent.com/6124793/132729353-bb9af3f8-6ab3-4850-be7c-1a0c554972b5.png)

This could be problem if both of these PRs were introducing new features and we wanted to have a tagged release, `v0.0.6`, that only had the changes from the first. That's an edge case scenario, and it's not necessarily our use case now, so I'm inclined to leave it as is, with a note that we should probably avoid merging PR's simultaneously in the future.

(If we ever do have a hard requirement for discrete versioned releases like that, we'd probably need to create an entirely different workflow similar to our [PR Check](https://github.com/seas-computing/.github/blob/main/workflow-templates/02-pr-check.yml) that blocks merging if there are any other workflows running)._